### PR TITLE
FIX: Dependancy order

### DIFF
--- a/ec2_setup/environment.yml
+++ b/ec2_setup/environment.yml
@@ -12,7 +12,7 @@
    - siphon
    - xarray
    - scipy
-   - boto3
    - boto
    - basemap
+   - boto3
 


### PR DESCRIPTION
if boto3 is listed before boto in the yml file boto is skipped..